### PR TITLE
Added CMakeLists.txt to allow the project to be compiled in Windows, …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+src/.vs/
+src/out/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(qrustyquake)
+
+set(SRC_DIR "${PROJECT_SOURCE_DIR}/.")
+set(SDL_DIR "${PROJECT_SOURCE_DIR}/../../SDL2-2.32.4")
+
+file(GLOB SRC_HEADERS "${SRC_DIR}/*.h")
+file(GLOB SRC_SOURCE "${SRC_DIR}/*.c")
+
+list(FILTER SRC_SOURCE EXCLUDE REGEX "net_bsd")
+list(FILTER SRC_SOURCE EXCLUDE REGEX "sys_sdl.c")
+
+add_executable(qrustyquake ${SRC_SOURCE})
+
+target_compile_definitions(qrustyquake PRIVATE -DWIN32_LEAN_AND_MEAN -D_USE_WINSOCK2)
+
+target_include_directories(qrustyquake PRIVATE "." ${SDL_DIR}/include)
+
+target_link_directories(qrustyquake PRIVATE "." ${SDL_DIR}/lib/x64)
+
+target_link_libraries(qrustyquake SDL2 SDL2main ws2_32)

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -248,13 +248,14 @@ void CL_KeepaliveMessage (void)
         SZ_Clear (&cls.message);
 }
 
+char    model_precache[MAX_MODELS][MAX_QPATH];
+char    sound_precache[MAX_SOUNDS][MAX_QPATH];
+
 void CL_ParseServerInfo()
 {
         const char      *str;
         int             i;
         int             nummodels, numsounds;
-        char    model_precache[MAX_MODELS][MAX_QPATH];
-        char    sound_precache[MAX_SOUNDS][MAX_QPATH];
 
         Con_DPrintf ("Serverinfo packet received.\n");
 

--- a/src/d_polyse.c
+++ b/src/d_polyse.c
@@ -110,8 +110,8 @@ void D_PolysetDraw()
 		else dither_pat = 0;
 	}
 	spanpackage_t spans[DPS_MAXSPANS + 1 +
-		((CACHE_SIZE - 1) / sizeof(spanpackage_t)) + 1]
-		__attribute__((aligned(CACHE_SIZE)));
+		((CACHE_SIZE - 1) / sizeof(spanpackage_t)) + 1]/*
+		__attribute__((aligned(CACHE_SIZE)))*/;
 	a_spans = (spanpackage_t *)
 		(((uintptr_t) & spans[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 	if (r_affinetridesc.drawtype)

--- a/src/d_sky.c
+++ b/src/d_sky.c
@@ -32,7 +32,7 @@ void D_DrawSkyScans8(espan_t *pspan)
 		int count = pspan->count;
 		int u = pspan->u; // calculate the initial s & t
 		int v = pspan->v;
-		fixed16_t s, t, snext, tnext;
+		fixed16_t s, t, snext = 0, tnext = 0;
 		D_Sky_uv_To_st(u, v, &s, &t);
 		do {
 			int spancount = count >= SKY_SPAN_MAX ?

--- a/src/mathlib.h
+++ b/src/mathlib.h
@@ -11,11 +11,7 @@
 #define VectorAdd(a,b,c) {c[0]=a[0]+b[0];c[1]=a[1]+b[1];c[2]=a[2]+b[2];}
 #define VectorCopy(a,b) {b[0]=a[0];b[1]=a[1];b[2]=a[2];}
 #define LERP(a, b, t) ((a) + ((b)-(a))*(t))
-#define IS_NAN(x) ({                    \
-        int temp;                       \
-        memcpy(&temp, &x, sizeof(int)); \
-        ((temp & nanmask) == nanmask);  \
-})
+#define IS_NAN(x) isnan(x)
 // johnfitz -- courtesy of lordhavoc
 #define VectorNormalizeFast(_v)                                           \
 {                                                                         \

--- a/src/miniz.h
+++ b/src/miniz.h
@@ -124,7 +124,7 @@
 #define NDEBUG /* disable assert()s */
 #endif
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /* Defines to completely disable specific portions of miniz.c: 
    If all macros here are defined the only functionality remaining will be CRC-32 and adler-32. */

--- a/src/model.c
+++ b/src/model.c
@@ -1406,7 +1406,7 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
                 //out->samples = loadmodel->lightdata + lofs; // TODO colored lighting
 
 		//johnfitz -- this section rewritten
-		if (!strncasecmp(out->texinfo->texture->name,"sky",3)) // sky surface //also note -- was Q_strncmp, changed to match qbsp
+		if (!q_strncasecmp(out->texinfo->texture->name,"sky",3)) // sky surface //also note -- was Q_strncmp, changed to match qbsp
 		{
 			out->flags |= (SURF_DRAWSKY | SURF_DRAWTILED);
 			Mod_PolyForUnlitSurface (out); //no more subdivision
@@ -1942,7 +1942,7 @@ static FILE *Mod_FindVisibilityExternal()
 			fclose(f);
 			return NULL;
 		}
-		if (!strcasecmp(header.mapname, shortname))
+		if (!q_strcasecmp(header.mapname, shortname))
 			break;
 		pos += header.filelen + VISPATCH_HEADER_LEN;
 		fseek(f, pos, SEEK_SET);
@@ -2026,7 +2026,7 @@ static void Mod_LoadBrushModel (model_t *mod, void *buffer)
 	Mod_LoadFaces (&header->lumps[LUMP_FACES], bsp2);
 	Mod_LoadMarksurfaces (&header->lumps[LUMP_MARKSURFACES], bsp2);
 	if (mod->bspversion == BSPVERSION && external_vis.value &&
-			sv.modelname[0] && !strcasecmp(loadname, sv.name)) {
+			sv.modelname[0] && !q_strcasecmp(loadname, sv.name)) {
 		FILE *fvis;
 		Con_DPrintf("trying to open external vis file\n");
 		fvis = Mod_FindVisibilityExternal();

--- a/src/quakedef.h
+++ b/src/quakedef.h
@@ -6,7 +6,7 @@
 #define __QUAKEDEF__
 // CyanBun96: imagine if we could keep all the includes in one place instead
 // of all over the .c and .h files that'd be cool right
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #ifdef __WIN32__
 #include <windows.h>
 #include <time.h>

--- a/src/r_alias.c
+++ b/src/r_alias.c
@@ -412,8 +412,8 @@ void R_AliasSetupFrame()
 
 void R_AliasDrawModel(alight_t *plighting)
 {
-	finalvert_t finalverts[MAXALIASVERTS]
-		__attribute__((aligned(CACHE_SIZE)));
+	finalvert_t finalverts[MAXALIASVERTS]/*
+		__attribute__((aligned(CACHE_SIZE)))*/;
 	auxvert_t auxverts[MAXALIASVERTS];
 	r_amodels_drawn++;
 	// cache align

--- a/src/r_edge.c
+++ b/src/r_edge.c
@@ -369,8 +369,8 @@ void R_GenerateSpansBackward()
 void R_ScanEdges()
 {
 	// Align the array itself to the cache size
-	byte basespans[MAXSPANS * sizeof(espan_t) + CACHE_SIZE]
-			__attribute__((aligned(CACHE_SIZE)));
+	byte basespans[MAXSPANS * sizeof(espan_t) + CACHE_SIZE]/*
+			__attribute__((aligned(CACHE_SIZE)))*/;
 	// Pointer to the aligned base of the spans
 	espan_t *basespan_p = (espan_t *) basespans;
 	// No more pointer adjustment needed because the array is aligned

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -603,15 +603,16 @@ void R_DrawBEntitiesOnList()
 	cur_ent_alpha = 1;
 }
 
+edge_t ledges[NUMSTACKEDGES + ((CACHE_SIZE - 1) / sizeof(edge_t)) + 1]/*
+	__attribute__((aligned(CACHE_SIZE)))*/;
+surf_t lsurfs[NUMSTACKSURFACES + ((CACHE_SIZE - 1) / sizeof(surf_t)) +
+1] /*__attribute__((aligned(CACHE_SIZE)))*/;
+
 void R_EdgeDrawing()
 {
 	// CyanBun96: windows would crash all over the place with the original
 	// alignment code, this might be compiler-dependent but it works
 	// Align the arrays themselves
-	edge_t ledges[NUMSTACKEDGES + ((CACHE_SIZE - 1) / sizeof(edge_t)) + 1]
-	    __attribute__((aligned(CACHE_SIZE)));
-	surf_t lsurfs[NUMSTACKSURFACES + ((CACHE_SIZE - 1) / sizeof(surf_t)) +
-		      1] __attribute__((aligned(CACHE_SIZE)));
 	// Accessing them directly without pointer adjustment
 	r_edges = auxedges ? auxedges : &ledges[0]; // already aligned
 	if (r_surfsonstack) {

--- a/src/snd_sdl.c
+++ b/src/snd_sdl.c
@@ -8,7 +8,7 @@
 
 #include "quakedef.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 static int	buffersize;
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -826,6 +826,7 @@ stats:
 	dev_stats.packetsize = msg->cursize;
 	dev_peakstats.packetsize = q_max(msg->cursize, dev_peakstats.packetsize);*/
 	//johnfitz
+	;
 }
 
 /*

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -512,45 +512,45 @@ nextmsg:
 			case clc_stringcmd:
 				s = MSG_ReadString ();
 				ret = 0;
-				if (strncasecmp(s, "status", 6) == 0)
+				if (q_strncasecmp(s, "status", 6) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "god", 3) == 0)
+				else if (q_strncasecmp(s, "god", 3) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "notarget", 8) == 0)
+				else if (q_strncasecmp(s, "notarget", 8) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "fly", 3) == 0)
+				else if (q_strncasecmp(s, "fly", 3) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "name", 4) == 0)
+				else if (q_strncasecmp(s, "name", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "noclip", 6) == 0)
+				else if (q_strncasecmp(s, "noclip", 6) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "setpos", 6) == 0)
+				else if (q_strncasecmp(s, "setpos", 6) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "say", 3) == 0)
+				else if (q_strncasecmp(s, "say", 3) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "say_team", 8) == 0)
+				else if (q_strncasecmp(s, "say_team", 8) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "tell", 4) == 0)
+				else if (q_strncasecmp(s, "tell", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "color", 5) == 0)
+				else if (q_strncasecmp(s, "color", 5) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "kill", 4) == 0)
+				else if (q_strncasecmp(s, "kill", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "pause", 5) == 0)
+				else if (q_strncasecmp(s, "pause", 5) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "spawn", 5) == 0)
+				else if (q_strncasecmp(s, "spawn", 5) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "begin", 5) == 0)
+				else if (q_strncasecmp(s, "begin", 5) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "prespawn", 8) == 0)
+				else if (q_strncasecmp(s, "prespawn", 8) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "kick", 4) == 0)
+				else if (q_strncasecmp(s, "kick", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "ping", 4) == 0)
+				else if (q_strncasecmp(s, "ping", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "give", 4) == 0)
+				else if (q_strncasecmp(s, "give", 4) == 0)
 					ret = 1;
-				else if (strncasecmp(s, "ban", 3) == 0)
+				else if (q_strncasecmp(s, "ban", 3) == 0)
 					ret = 1;
 
 				if (ret == 1)

--- a/src/vgatext.h
+++ b/src/vgatext.h
@@ -4,7 +4,7 @@
 #ifndef VGATEXT_H
 #define VGATEXT_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 // draw rendered vga text in the specified window. returns -1 on error.
 int vgatext_main(SDL_Window *window, Uint16 *screen);


### PR DESCRIPTION
…using either CMake directly, or using VS 2022 through its integration with CMake.

To compile the project using these changes, make sure to download and uncompress SDL2-devel-2.32.4-VC.zip, from github, into a folder next to the `qrustyquake` folder.

Changes to the source code include:
* Changing strcasecmp() to q_strcasecmp() and strncasecmp() to q_strncasecmp();
* Changing #include <SDL2/SDL2.h> to #include <SDL.h> (but still using SDL2-2.32.4, as noted above);
* Moved some very large local variables from CL_ParseServerInfo, D_PolysetDraw() and R_EdgeDrawing() into global space, to avoid stack overflows;
* Added one semicolon at the end of SV_WriteEntitiesToClient() - the compiler complained about it (?);
* Commented out the existing __attribute__((aligned)) tags (I know of no alternative to this, other than maybe creating the memory dynamically and then making sure it is aligned);
* Force initialization of snext and tnext in D_DrawSkyScans8(), as an exception jumps sometimes at runtime for being uninitialized (weird);
* Replaced body of IS_NAN(x) with a straight call to isnan() - since it uses a syntax that is not supported by MSVC, and also it does not seem to be used if the "developer" var is not on;
* Replaced call to "hstrerror(h_errno)" with its equivalent in Windows, but only if _WIN32 is defined.