### PR TITLE
Makefile: use pkg-config to to get SDL3 cflags and libs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
+PKGCONFIG ?= pkg-config
 CC = gcc
-CFLAGS = -c -Wall -Wextra -D_DEFAULT_SOURCE
-LDFLAGS = -lm -lSDL3
+CFLAGS = -c -Wall -Wextra -D_DEFAULT_SOURCE $(shell $(PKGCONFIG) --cflags sdl3)
+LDFLAGS = -lm $(shell $(PKGCONFIG) --libs sdl3)
 TARGET = qrustyquake
 SRCS = chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
 	cl_tent.c cmd.c common.c console.c crc.c \


### PR DESCRIPTION
should hopefully make the build system more portable between different *nix systems!