### PR TITLE
Add OGG/MP3 music support ("cdaudio" driver)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,10 @@ project(qrustyquake LANGUAGES C HOMEPAGE_URL "https://github.com/cyanbun96/qrust
 
 if(EMSCRIPTEN)
 	find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3-static)
+	find_package(SDL3_mixer REQUIRED CONFIG REQUIRED COMPONENTS SDL3_mixer-static)
 else()
 	find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3-shared)
+	find_package(SDL3_mixer REQUIRED CONFIG REQUIRED COMPONENTS SDL3_mixer-shared)
 endif()
 
 file(GLOB QRUSTYQUAKE_HEADERS "${PROJECT_SOURCE_DIR}/src/*.h")
@@ -13,8 +15,8 @@ file(GLOB QRUSTYQUAKE_SOURCES "${PROJECT_SOURCE_DIR}/src/*.c")
 add_executable(qrustyquake)
 
 if(EMSCRIPTEN)
-	target_compile_options(qrustyquake PRIVATE -sUSE_SDL=3)
-	target_link_options(qrustyquake PRIVATE -sUSE_SDL=3)
+	target_compile_options(qrustyquake PRIVATE -sUSE_SDL=3 -sUSE_SDL_MIXER=3)
+	target_link_options(qrustyquake PRIVATE -sUSE_SDL=3 -sUSE_SDL_MIXER=3)
 	target_link_options(qrustyquake PRIVATE -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=1gb -sSTACK_SIZE=10mb)
 	target_link_options(qrustyquake PRIVATE --preload-file id1)
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -36,7 +38,7 @@ endif()
 target_sources(qrustyquake PRIVATE ${QRUSTYQUAKE_SOURCES})
 
 target_include_directories(qrustyquake PRIVATE "${PROJECT_SOURCE_DIR}/src/")
-target_link_libraries(qrustyquake PRIVATE SDL3::SDL3)
+target_link_libraries(qrustyquake PRIVATE SDL3::SDL3 SDL3_mixer::SDL3_mixer)
 
 find_library(libmath m)
 if(libmath)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,9 @@
 PKGCONFIG ?= pkg-config
 CC = gcc
-CFLAGS = -c -Wall -Wextra -D_DEFAULT_SOURCE $(shell $(PKGCONFIG) --cflags sdl3)
-LDFLAGS = -lm $(shell $(PKGCONFIG) --libs sdl3)
+CFLAGS = -c -Wall -Wextra -D_DEFAULT_SOURCE $(shell $(PKGCONFIG) --cflags sdl3 sdl3-mixer)
+LDFLAGS = -lm $(shell $(PKGCONFIG) --libs sdl3 sdl3-mixer)
 TARGET = qrustyquake
-SRCS = chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
+SRCS = cdaudio.c chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
 	cl_tent.c cmd.c common.c console.c crc.c \
 	cvar.c d_edge.c \
 	d_part.c d_polyse.c d_scan.c d_sky.c d_sprite.c \

--- a/src/Makefile.freebsd
+++ b/src/Makefile.freebsd
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -c -Wall -Wextra
 LDFLAGS = -lm -lSDL2
 TARGET = qrustyquake
-SRCS = chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
+SRCS = cdaudio.c chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
 	cl_tent.c cmd.c common.c console.c crc.c \
 	cvar.c d_edge.c \
 	d_part.c d_polyse.c d_scan.c d_sky.c d_sprite.c \

--- a/src/Makefile.openbsd
+++ b/src/Makefile.openbsd
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -c -Wall -Wextra -I/usr/local/include -I/usr/local/include/SDL2 -I/usr/X11R6/include -D_REENTRANT -I/usr/X11R6/include
 LDFLAGS = -lm -lSDL2 -L/usr/local/lib -lSDL2 -L/usr/X11R6/lib
 TARGET = qrustyquake
-SRCS = chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
+SRCS = cdaudio.c chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
 	cl_tent.c cmd.c common.c console.c crc.c \
 	cvar.c d_edge.c \
 	d_part.c d_polyse.c d_scan.c d_sky.c d_sprite.c \

--- a/src/Makefile.w64
+++ b/src/Makefile.w64
@@ -24,7 +24,7 @@ CFLAGS = $(CFLAGS_BASE) $(RELEASE_FLAGS) $(SDL_CFLAGS)
 LDFLAGS = $(LDFLAGS_BASE)
 endif
 
-SRCS = chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
+SRCS = cdaudio.c chase.c cl_demo.c cl_input.c cl_main.c cl_parse.c \
 	cl_tent.c cmd.c common.c console.c crc.c \
 	cvar.c d_edge.c \
 	d_part.c d_polyse.c d_scan.c d_sky.c d_sprite.c \

--- a/src/cdaudio.c
+++ b/src/cdaudio.c
@@ -1,0 +1,113 @@
+// Copyright (C) 1996-2001 Id Software, Inc.
+// Copyright (C) 2002-2009 John Fitzgibbons and others
+// Copyright (C) 2010-2014 QuakeSpasm developers
+// GPLv3 See LICENSE for details.
+#include "quakedef.h"
+
+// FIXME: add to globals.h
+u8 *COM_LoadTempFile(const s8 *path, u32 *path_id);
+
+static Mix_Music *current_music = NULL;
+
+void CDAudio_Play(u8 track, bool looping)
+{
+	char filename[MAX_QPATH];
+	u8 *file = NULL;
+	SDL_IOStream *io = NULL;
+	Mix_Music *music = NULL;
+
+	q_snprintf(filename, sizeof(filename), "music/track%02d.ogg", (int)track);
+
+	file = COM_LoadTempFile(filename, NULL);
+	if (!file)
+	{
+		q_snprintf(filename, sizeof(filename), "music/track%02d.mp3", (int)track);
+		file = COM_LoadTempFile(filename, NULL);
+		if (!file)
+		{
+			Con_Printf("file for track %02d not found\n", (int)track);
+			return;
+		}
+	}
+
+	io = SDL_IOFromConstMem(file, com_filesize);
+	if (!io)
+	{
+		Con_Printf("failed to create IOStream for track %02d: %s\n", (int)track, SDL_GetError());
+		return;
+	}
+
+	music = Mix_LoadMUS_IO(io, true);
+	if (!music)
+	{
+		Con_Printf("failed to load track %02d: %s\n", (int)track, SDL_GetError());
+		return;
+	}
+
+	CDAudio_Stop();
+
+	current_music = music;
+
+	if (!Mix_PlayMusic(current_music, looping ? -1 : 0))
+	{
+		Con_Printf("failed to play track %02d: %s\n", (int)track, SDL_GetError());
+		return;
+	}
+}
+
+void CDAudio_Stop()
+{
+	if (current_music)
+		Mix_FreeMusic(current_music);
+	current_music = NULL;
+}
+
+void CDAudio_Pause()
+{
+	Mix_PauseMusic();
+}
+
+void CDAudio_Resume()
+{
+	Mix_ResumeMusic();
+}
+
+void CDAudio_Update()
+{
+	static float last_volume = 0;
+
+	if (bgmvolume.value < 0)
+		Cvar_SetQuick(&bgmvolume, "0");
+	if (bgmvolume.value > 1)
+		Cvar_SetQuick(&bgmvolume, "1");
+
+	if (last_volume != bgmvolume.value)
+		Mix_VolumeMusic(bgmvolume.value * MIX_MAX_VOLUME);
+}
+
+bool CDAudio_Init()
+{
+	// FIXME: more formats? other ones that mod care about?
+	MIX_InitFlags initflags = Mix_Init(MIX_INIT_MP3 | MIX_INIT_OGG | MIX_INIT_OPUS);
+	if (!(initflags & MIX_INIT_MP3) || !(initflags & MIX_INIT_OGG) || !(initflags & MIX_INIT_OPUS))
+	{
+		Con_Printf("Failed to initialize SDL Mixer: %s\n", SDL_GetError());
+		return false;
+	}
+
+	if (!Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, NULL))
+	{
+		Con_Printf("Failed to initialize SDL Mixer: %s\n", SDL_GetError());
+		return false;
+	}
+
+	Con_Printf("SDL Mixer initialized\n");
+
+	return true;
+}
+
+void CDAudio_Shutdown()
+{
+	CDAudio_Stop();
+	Mix_Quit();
+}

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -628,8 +628,10 @@ void CL_ParseServerMessage()
 		break;
 	case svc_setpause:
 		cl.paused = MSG_ReadByte();
-		//TODOif(cl.paused)BGM_Pause();
-		//else BGM_Resume();
+		if(cl.paused)
+			CDAudio_Pause();
+		else
+			CDAudio_Resume();
 		break;
 	case svc_signonnum:
 		i = MSG_ReadByte();
@@ -662,11 +664,10 @@ void CL_ParseServerMessage()
 	case svc_cdtrack:
 		cl.cdtrack = MSG_ReadByte();
 		cl.looptrack = MSG_ReadByte();
-		//TODOif((cls.demoplayback || cls.demorecording) &&
-		//(cls.forcetrack != -1) )
-		//TODO BGM_PlayCDtrack((u8)cls.forcetrack, 1);
-		//TODOelse
-		//TODO BGM_PlayCDtrack((u8)cl.cdtrack, 1);
+		if((cls.demoplayback || cls.demorecording) && (cls.forcetrack != -1))
+			CDAudio_Play((u8)cls.forcetrack, true);
+		else
+			CDAudio_Play((u8)cl.cdtrack, true);
 		break;
 	case svc_intermission:
 		cl.intermission = 1;

--- a/src/globals.h
+++ b/src/globals.h
@@ -761,5 +761,12 @@ EX u32 sb_updates; // if >= vid.numpages, no update needed             // sbar.c
 u8 *Image_LoadImage(const s8 *name, s32 *width, s32 *height);         // image.c
 bool nameInList(const s8 *list, const s8 *name);                      // model.c
 void PF_changeyaw();                                                // pr_cmds.c
+void CDAudio_Play(u8 track, bool looping);                          // cdaudio.c
+void CDAudio_Stop();
+void CDAudio_Pause();
+void CDAudio_Resume();
+void CDAudio_Update();
+bool CDAudio_Init();
+void CDAudio_Shutdown();
 #undef EX
 #endif

--- a/src/host.c
+++ b/src/host.c
@@ -375,6 +375,7 @@ void _Host_Frame(f32 time)
 		CL_DecayLights();
 	} else
 		S_Update(vec3_origin, vec3_origin, vec3_origin, vec3_origin);
+	CDAudio_Update();
 	if(host_speeds.value){
 		static f64 pass[3] = {0.0, 0.0, 0.0};
 		static f64 elapsed = 0.0;
@@ -470,6 +471,7 @@ void Host_Init()
 		SCR_Init();
 		R_Init();
 		S_Init();
+		CDAudio_Init();
 		Sbar_Init();
 		CL_Init();
 	}
@@ -495,6 +497,7 @@ void Host_Shutdown()
 	// keep Con_Printf from trying to update the screen
 	scr_disabled_for_loading= 1;
 	Host_WriteConfiguration();
+	CDAudio_Shutdown();
 	NET_Shutdown();
 	S_Shutdown();
 	if(cls.state != ca_dedicated){

--- a/src/sys_sdl.c
+++ b/src/sys_sdl.c
@@ -13,6 +13,7 @@ void Sys_Printf(const s8 *fmt, ...)
 
 void Sys_Quit()
 {
+	CDAudio_Stop();
         Uint16 *screen; // erysdren (it/its)
         if(registered.value) screen = (Uint16 *)COM_LoadHunkFile("end2.bin", 0);
         else screen = (Uint16 *)COM_LoadHunkFile("end1.bin", 0);
@@ -30,6 +31,7 @@ void Sys_Error(const s8 *error, ...)
 {
 	va_list argptr;
 	s8 str[1024];
+	CDAudio_Stop();
 	va_start(argptr, error);
 	vsprintf(str, error, argptr);
 	va_end(argptr);

--- a/src/sysincludes.h
+++ b/src/sysincludes.h
@@ -41,6 +41,7 @@
 #include <io.h>
 #endif
 #include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif


### PR DESCRIPTION
pretty simple and straightforward use of SDL_Mixer. no frills, except for the `bgmvolume` cvar. a big TODO is to add the console commands for playing, stopping and starting cdaudio music, like FTEQW and other ports have. good enough to play the game, though! :3