### PR TITLE
Fixes crashes and fixes warnings

### DIFF
--- a/src/d_edge.c
+++ b/src/d_edge.c
@@ -269,7 +269,7 @@ void D_DrawSurfacesPass3()
 	for (surf_t *s = &surfaces[1]; s < surface_p; s++) {
 		if (!s->spans) continue;
 		msurface_t *pface = s->data;
-		u64 is_ent = (u64)s->entity & 0xffff000; // FIXME
+		u64 is_ent = (ul64)s->entity & 0xffff000ull;
 		if(!(s->flags&SURF_DRAWTURB) && !is_ent) continue;
 		if (pface == 0) continue;
 		d_zistepu = s->d_zistepu;

--- a/src/d_polyse.c
+++ b/src/d_polyse.c
@@ -399,7 +399,7 @@ void D_PolysetDrawSpans8(spanpackage_t *pspanpackage)
 			s32 ltfrac = pspanpackage->tfrac;
 			s32 llight = pspanpackage->light;
 			s32 lzi = pspanpackage->zi;
-			if ((u64)(lpz + lcount - d_pzbuffer) > vid.width * vid.height * sizeof(s16)) {
+			if (lpz + lcount - d_pzbuffer > vid.width * vid.height * sizeof(s16)) {
 				Con_DPrintf ("Invalid span length: %d %d\n", 
 					lpz + lcount - d_pzbuffer, vid.width * vid.height * sizeof(s16));
 				break;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -1,15 +1,16 @@
 #ifndef QTYPEDEFS_
 #define QTYPEDEFS_
-typedef unsigned char  u8;
-typedef char           s8;
-typedef unsigned short u16;
-typedef short          s16;
-typedef unsigned int   u32;
-typedef int            s32;
-typedef unsigned long  u64;
-typedef long           s64;
-typedef float          f32;
-typedef double         f64;
+typedef unsigned char      u8;
+typedef char               s8;
+typedef unsigned short     u16;
+typedef short              s16;
+typedef unsigned int       u32;
+typedef int                s32;
+typedef unsigned long      u64;
+typedef unsigned long long ul64;
+typedef long               s64;
+typedef float              f32;
+typedef double             f64;
 
 typedef struct { // specified by the host system                   // quakedef.h
 	s8 *basedir;

--- a/src/vid_sdl.c
+++ b/src/vid_sdl.c
@@ -247,10 +247,10 @@ void VID_Init(SDL_UNUSED u8 *palette)
 
 void VID_Shutdown()
 {
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 	if(screen != NULL)
 		SDL_UnlockSurface(screen);
 	SDL_UnlockTexture(texture);
-	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 
 void VID_CalcScreenDimensions(SDL_UNUSED cvar_t *cvar)


### PR DESCRIPTION
Fixes a warning where an 8 byte entity_t is being truncated to a 4 byte unsigned long.  Changed to an unsigned long long which is 64bit wide on all systems.

Also fixed a crash where a forced unsigned 64bit integer is being used for the vid.width buffer.  Not a good idea.

Also fixed a crash when exiting because you should not quit SDL3 'after' assets and resources have been free'd..  this should be done 'before',