### PR TITLE
Fix memory leak when loading new map

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,10 +43,14 @@ CFLAGS += -DSDL_DISABLE_IMMINTRIN_H
 endif
 
 DEBUG_FLAGS = -g -O0 -DDEBUG
-RELEASE_FLAGS = -O3 -flto -g
+RELEASE_FLAGS = -O3 -flto=auto -g
 
 ifeq ($(BUILD_TYPE), debug)
 	CFLAGS += $(DEBUG_FLAGS)
+	ifeq ($(ASAN), 1)
+		CFLAGS += -fsanitize=address -fsanitize-recover=address -fno-omit-frame-pointer
+		LDFLAGS += -fsanitize=address
+	endif
 else
 	CFLAGS += $(RELEASE_FLAGS)
 endif
@@ -61,6 +65,9 @@ $(TARGET): $(OBJS)
 
 debug:
 	$(MAKE) BUILD_TYPE=debug
+
+asan:
+	$(MAKE) BUILD_TYPE=debug ASAN=1
 
 release:
 	$(MAKE) BUILD_TYPE=release

--- a/src/host.c
+++ b/src/host.c
@@ -249,6 +249,7 @@ Con_Printf("Host_ShutdownServer: NET_SendToAll failed for %u clients\n", count);
 	s32 i = 0;
 	for(host_client = svs.clients; i < svs.maxclients; i++, host_client++)
 		if(host_client->active) SV_DropClient(crash);
+	free(sv.edicts);
 	memset(&sv, 0, sizeof(sv)); // clear structures
 	memset(svs.clients, 0, svs.maxclientslimit * sizeof(client_t));
 }
@@ -260,6 +261,7 @@ void Host_ClearMemory() // This clears all the memory used by both the client
 	Mod_ClearAll();
 	if(host_hunklevel) Hunk_FreeToLowMark(host_hunklevel);
 	cls.signon = 0;
+	free(sv.edicts);
 	memset(&sv, 0, sizeof(sv));
 	memset(&cl, 0, sizeof(cl));
 }


### PR DESCRIPTION
malloc'd `sv.edicts` was not freed between map loads.

Found this issue running the program compiled with the address sanitizer for which I added a target in the `Makefile` (`make asan`).

Also updated flag to `-flto=auto` to fix a gcc warning that made linking much slower on a single core.