### PR TITLE
Fix some invalid scr_uiscale values causing 100% CPU Usage

### DIFF
--- a/src/vid_sdl.c
+++ b/src/vid_sdl.c
@@ -117,7 +117,7 @@ void VID_SetBorderless()
 
 void VID_UpdateUIScale(SDL_UNUSED cvar_t *cvar)
 {
-	if(vid.width / 320 >= scr_uiscale.value && scr_uiscale.value > 0){
+	if(vid.width / 320 >= scr_uiscale.value && scr_uiscale.value >= 1){
 		uiscale = scr_uiscale.value;
 		vid.recalc_refdef = 1;
 	} else {


### PR DESCRIPTION
Do not allow scr_uiscale values in ]0..1[ float range as it made `uiscale` value 0, causing 100% CPU usage loop. Min allowed `scr_uiscale` is 1.