### PR TITLE
Fix - SBAR level name sometimes bleeding off-screen

### DIFF
--- a/src/sbar.c
+++ b/src/sbar.c
@@ -407,7 +407,7 @@ void Sbar_SoloScoreboard()
 	Draw_StringScaled(WW/2+24*SCL+xx, HH-20*SCL, str, SCL);
 	Sbar_UpdateLevelNameBuf();
 	s32 l = Q_strlen (lvnamebuf);
-	Draw_StringScaled(WW/2+72*SCL+xx-l*4, HH-12*SCL, lvnamebuf, SCL);
+	Draw_StringScaled(WW/2+72*SCL+xx-l*4*SCL, HH-12*SCL, lvnamebuf, SCL);
 }
 
 void Sbar_CalcPos()


### PR DESCRIPTION
Added the missing SCL multiplier to the string length offset in Sbar_SoloScoreboard().
This ensures the text shifts left correctly when scaled up, preventing long level names from wrapping to the next line.

Found this only AFTER I merged my other update -_-