### PR TITLE
Added resurrect command for SP

### DIFF
--- a/src/host_cmd.c
+++ b/src/host_cmd.c
@@ -1227,6 +1227,57 @@ void Host_Mods_f()
         else Con_Printf("no mods found\n");
 }
 
+void Cmd_Resurrect_f()
+{
+    edict_t *ent;
+    int w, old_self;
+    
+    if (pr_global_struct->deathmatch) return;
+    
+    if (!sv.active || cls.demoplayback) {
+        Con_Printf("You must be in a game to resurrect.\n");
+        return;
+    }
+    
+    if (sv.max_edicts <= 1) return;
+    ent = EDICT_NUM(1);
+    
+    if (!ent || ent->free){
+        Con_Printf("Error: PLAYER edict missing/freed.\n");
+        return;
+    }
+    if (ent->v.health > 0) {
+	Con_Printf("You are still alive!\n");
+	return;
+    }
+    // 2. Chained assignments compress the Physics & Camera resets
+    ent->v.health = 100;
+    ent->v.deadflag = DEAD_NO;
+    ent->v.takedamage = DAMAGE_AIM;
+    ent->v.solid = SOLID_SLIDEBOX;
+    ent->v.movetype = MOVETYPE_WALK;
+    ent->v.modelindex = 1;
+
+    ent->v.punchangle[0] = ent->v.punchangle[1] = ent->v.punchangle[2] = 0;
+    cl.punchangle[0] = cl.punchangle[1] = cl.punchangle[2] = 0;
+
+    ent->v.view_ofs[0] = ent->v.view_ofs[1] = ent->v.angles[2] = cl.viewangles[2] = 0;
+    ent->v.view_ofs[2] = cl.viewheight = 22;
+
+    // 3. Compact Weapon Logic (Ternary Chain)
+    w = (int)ent->v.weapon;
+    ent->v.weapon = 0;
+    ent->v.impulse = (w==IT_AXE)?1 : (w==IT_SHOTGUN)?2 : (w==IT_SUPER_SHOTGUN)?3 : (w==IT_NAILGUN)?4 : (w==IT_SUPER_NAILGUN)?5 : (w==IT_GRENADE_LAUNCHER)?6 : (w==IT_ROCKET_LAUNCHER)?7 : (w==IT_LIGHTNING)?8 : 10;
+
+    // 4. Synchronous VM Execution
+    old_self = pr_global_struct->self;
+    pr_global_struct->self = EDICT_TO_PROG(ent);
+    PR_ExecuteProgram(pr_global_struct->PlayerPostThink);
+    pr_global_struct->self = old_self;
+
+    Con_Printf("Resurrection successful.\n");
+}
+
 void Host_InitCommands()
 {
 	Cmd_AddCommand("maps", Host_Maps_f);
@@ -1235,6 +1286,7 @@ void Host_InitCommands()
 	Cmd_AddCommand("status", Host_Status_f);
 	Cmd_AddCommand("quit", Host_Quit_f);
 	Cmd_AddCommand("god", Host_God_f);
+	Cmd_AddCommand("resurrect", Cmd_Resurrect_f);
 	Cmd_AddCommand("notarget", Host_Notarget_f);
 	Cmd_AddCommand("fly", Host_Fly_f);
 	Cmd_AddCommand("map", Host_Map_f);


### PR DESCRIPTION
given many Doom engines (with a console) have had support for a resurrect command for a while, I figured Quake was long overdue for one.

The only other engine I'm aware of that has a similar implementation is QuakeSpasm-Spiked-Multiplayer, so it'll be exciting to see if any players get a use out of it.

Also if you're aware of how to clean up the resurrect function and make it prettier, by all means go ahead >3< i just kinda brute forced it to work.