### PR TITLE
Console Overflow + DM Scoreboard Bugfixes!

### DIFF
--- a/src/host_cmd.c
+++ b/src/host_cmd.c
@@ -1316,6 +1316,7 @@ void Cmd_Resurrect_f()
         case IT_GRENADE_LAUNCHER: ent->v.impulse = 6; break;
         case IT_ROCKET_LAUNCHER:  ent->v.impulse = 7; break;
         case IT_LIGHTNING:        ent->v.impulse = 8; break;
+		case IT_SUPER_LIGHTNING   ent->v.impulse = 1; break;
         default:                  ent->v.impulse = 10; break;
     }
 	ent->v.button0 = ent->v.button1 = ent->v.button2 = 0;

--- a/src/host_cmd.c
+++ b/src/host_cmd.c
@@ -1307,19 +1307,10 @@ void Cmd_Resurrect_f()
 	// 4. Compact Weapon Logic (Ternary Chain)
 	s32 w = ent->v.weapon;
 	ent->v.weapon = 0;
-    switch (w) {
-        case IT_AXE:              ent->v.impulse = 1; break;
-        case IT_SHOTGUN:          ent->v.impulse = 2; break;
-        case IT_SUPER_SHOTGUN:    ent->v.impulse = 3; break;
-        case IT_NAILGUN:          ent->v.impulse = 4; break;
-        case IT_SUPER_NAILGUN:    ent->v.impulse = 5; break;
-        case IT_GRENADE_LAUNCHER: ent->v.impulse = 6; break;
-        case IT_ROCKET_LAUNCHER:  ent->v.impulse = 7; break;
-        case IT_LIGHTNING:        ent->v.impulse = 8; break;
-		case IT_SUPER_LIGHTNING   ent->v.impulse = 1; break;
-        default:                  ent->v.impulse = 10; break;
-    }
-	ent->v.button0 = ent->v.button1 = ent->v.button2 = 0;
+	ent->v.impulse=(w==IT_AXE)?1:(w==IT_SHOTGUN)?2:(w==IT_SUPER_SHOTGUN)?3:
+		(w==IT_NAILGUN)?4:(w==IT_SUPER_NAILGUN)?5:
+		(w==IT_GRENADE_LAUNCHER)?6:(w==IT_ROCKET_LAUNCHER)?7:
+		(w==IT_LIGHTNING)?8:(w==IT_SUPER_LIGHTNING)?1:10;
 	// 5. Synchronous VM Execution
 	s32 old_self = pr_global_struct->self;
 	pr_global_struct->self = EDICT_TO_PROG(ent);

--- a/src/host_cmd.c
+++ b/src/host_cmd.c
@@ -1307,10 +1307,18 @@ void Cmd_Resurrect_f()
 	// 4. Compact Weapon Logic (Ternary Chain)
 	s32 w = ent->v.weapon;
 	ent->v.weapon = 0;
-	ent->v.impulse=(w==IT_AXE)?1:(w==IT_SHOTGUN)?2:(w==IT_SUPER_SHOTGUN)?3:
-		(w==IT_NAILGUN)?4:(w==IT_SUPER_NAILGUN)?5:
-		(w==IT_GRENADE_LAUNCHER)?6:(w==IT_ROCKET_LAUNCHER)?7:
-		(w==IT_LIGHTNING)?8:(w==IT_SUPER_LIGHTNING)?1:10;
+    switch (w) {
+        case IT_AXE:              ent->v.impulse = 1; break;
+        case IT_SHOTGUN:          ent->v.impulse = 2; break;
+        case IT_SUPER_SHOTGUN:    ent->v.impulse = 3; break;
+        case IT_NAILGUN:          ent->v.impulse = 4; break;
+        case IT_SUPER_NAILGUN:    ent->v.impulse = 5; break;
+        case IT_GRENADE_LAUNCHER: ent->v.impulse = 6; break;
+        case IT_ROCKET_LAUNCHER:  ent->v.impulse = 7; break;
+        case IT_LIGHTNING:        ent->v.impulse = 8; break;
+        default:                  ent->v.impulse = 10; break;
+    }
+	ent->v.button0 = ent->v.button1 = ent->v.button2 = 0;
 	// 5. Synchronous VM Execution
 	s32 old_self = pr_global_struct->self;
 	pr_global_struct->self = EDICT_TO_PROG(ent);

--- a/src/keys.c
+++ b/src/keys.c
@@ -137,6 +137,7 @@ void Key_Console(s32 key) // Line typing into the console
 		edit_line = (edit_line + 1) & 31;
 		history_line = edit_line;
 		key_lines[edit_line][0] = ']';
+		key_lines[edit_line][1] = 0;
 		key_linepos = 1;
 		if(cls.state == ca_disconnected) // force an update because
 			SCR_UpdateScreen(); // the command may take some time

--- a/src/sbar.c
+++ b/src/sbar.c
@@ -905,6 +905,7 @@ void Sbar_DeathmatchOverlay()
 		y = 40*SCL;
 	}
 	for (s32 i = 0; i < scoreboardlines; i++) {
+		if (!sb_showscores && y > HH - 60*SCL) break;
 		s32 k = fragsort[i];
 		scoreboard_t *s = &cl.scores[k];
 		if (!s->name[0])


### PR DESCRIPTION
Hello again, my Quake-loving friend from afar!
Two little fixes (I think) to keep things neat, tidy, and above all, working as intended:

1. In Multiplayer NetQuake Deathmatches, sometimes the scoreboard or player tally would draw itself between the HUD and the armor amount numbers when not engaged. This was visible after a certain number of players (i think like 4 or 5) join the server. The fix in 'sbar.c' should cover this; I was not able to reproduce this error after this fix. But my fix was started on an older codebase (0.7.0-ish), so maybe this bug was slightly addressed since, but hey, an extra check may not hurt, maybe(?)
_(^^^ This is what I get when I cross-develop on both an outdated Arch Linux system and a Windows 11 gaming pc)_

3. The console had a finicky little issue where after the console hit its command history buffer limit (hardcoded as 32), it would start autofilling the commands in the order they were entered after it wrapped back around to 0. The fix in 'keys.c' makes sure the line is cleared regardless of prior command history, prevents the dreaded autofill, and retains the memory-tight history of 32 max commands. (I almost increased the maximum buffer to 2048 to prevent the likelihood of a wraparound, not realizing I could clear the line for like 20 whole minutes XD)

Hope you've been well, and I can't wait to see what's in store going forward! I can't overstate just how grateful I am to help make this engine be all it can be!

Also in good fun, here's an icon I've been using to distinguish the engine in a massive folder of other ports :P
Feel free to use it if you'd like!

<img width="128" height="128" alt="QrustyQuake Icon Idea" src="https://github.com/user-attachments/assets/2743b70d-5685-408a-8697-5063eb2862d6" />

