### PR TITLE
Optional WinQuake exit screen :D

### DIFF
--- a/src/cvarlist.c
+++ b/src/cvarlist.c
@@ -5,6 +5,7 @@ cvar_t scr_uiscale=                                  {"scr_uiscale", "1", 1,ZR};
 cvar_t scr_lockuiscale=                          {"scr_lockuiscale", "0", 1,ZR};
 cvar_t sensitivityyscale=                      {"sensitivityyscale", "1", 1,ZR};
 cvar_t _windowed_mouse=                          {"_windowed_mouse", "0", 1,ZR};
+cvar_t win_quit=									    {"win_quit", "0", 1,ZR};
 cvar_t newoptions=                                    {"newoptions", "1", 1,ZR};
 cvar_t aspectr=                                          {"aspectr", "0", 1,ZR};
 cvar_t realwidth=                                      {"realwidth", "0", 0,ZR};

--- a/src/cvarlist.h
+++ b/src/cvarlist.h
@@ -1,5 +1,5 @@
 extern cvar_t vid_mode, _vid_default_mode_win, scr_uiscale, sensitivityyscale,
-_windowed_mouse, newoptions, aspectr, realwidth, realheight, r_draworder,
+_windowed_mouse, win_quit, newoptions, aspectr, realwidth, realheight, r_draworder,
 r_speeds, r_timegraph, r_graphheight, r_clearcolor, r_waterwarp, r_fullbright,
 r_drawentities, r_drawviewmodel, r_aliasstats, r_dspeeds, r_drawflat, r_ambient,
 r_reportsurfout, r_numsurfs, r_reportedgeout, r_novis, r_particlescale,

--- a/src/menu.c
+++ b/src/menu.c
@@ -3188,22 +3188,22 @@ void M_Quit_Draw()
 	}
 
 	if (win_quit.value) {
-		M_DrawTextBox(0, 0, 38, 23);
+		M_DrawTextBox (0, 0, 38, 23);
 		M_PrintWhite (16, 12,  "  Quake version 1.09 by id Software\n\n");
 		M_PrintWhite (16, 28,  "Programming        Art \n");
-		M_Print      (16, 36,  " John Carmack       Adrian Carmack\n");
-		M_Print      (16, 44,  " Michael Abrash     Kevin Cloud\n");
-		M_Print      (16, 52,  " John Cash          Paul Steed\n");
-		M_Print      (16, 60,  " Dave 'Zoid' Kirsch\n");
-		M_PrintWhite (16, 68,  "Design             Biz\n");
-		M_Print      (16, 76,  " John Romero        Jay Wilbur\n");
-		M_Print      (16, 84,  " Sandy Petersen     Mike Wilson\n");
-		M_Print      (16, 92,  " American McGee     Donna Jackson\n");
-		M_Print      (16, 100, " Tim Willits        Todd Hollenshead\n");
-		M_PrintWhite (16, 108, "Support            Projects\n");
-		M_Print      (16, 116, " Barrett Alexander  Shawn Green\n");
-		M_PrintWhite (16, 124, "Sound Effects\n");
-		M_Print      (16, 132, " Trent Reznor and Nine Inch Nails\n\n");
+		M_Print (16, 36,  " John Carmack       Adrian Carmack\n");
+		M_Print (16, 44,  " Michael Abrash     Kevin Cloud\n");
+		M_Print (16, 52,  " John Cash          Paul Steed\n");
+		M_PrintWhite (16, 60,  "Design             Biz\n");
+		M_Print (16, 68,  " John Romero        Jay Wilbur\n");
+		M_Print (16, 76,  " Sandy Petersen     Mike Wilson\n");
+		M_Print (16, 84,  " American McGee     Donna Jackson\n");
+		M_Print (16, 92,  " Tim Willits        Todd Hollenshead\n");
+		M_PrintWhite (16, 100, "Support            Projects\n");
+		M_Print (16, 108, " Barrett Alexander  Shawn Green\n");
+		M_PrintWhite (16, 116, "Sound Effects\n");
+		M_Print (16, 124, " Trent Reznor and Nine Inch Nails\n\n");
+	
 		M_PrintWhite (16, 140, "Quake is a trademark of Id Software,\n");
 		M_PrintWhite (16, 148, "inc., (c)1996 Id Software, inc. All\n");
 		M_PrintWhite (16, 156, "rights reserved. NIN logo is a\n");

--- a/src/menu.c
+++ b/src/menu.c
@@ -3186,11 +3186,37 @@ void M_Quit_Draw()
 		M_Draw();
 		m_state = m_quit;
 	}
-	M_DrawTextBox(56, 76, 24, 4);
-	M_Print(64, 84, quitMessage[msgNumber * 4 + 0]);
-	M_Print(64, 92, quitMessage[msgNumber * 4 + 1]);
-	M_Print(64, 100, quitMessage[msgNumber * 4 + 2]);
-	M_Print(64, 108, quitMessage[msgNumber * 4 + 3]);
+
+	if (win_quit.value) {
+		M_DrawTextBox(0, 0, 38, 23);
+		M_PrintWhite (16, 12,  "  Quake version 1.09 by id Software\n\n");
+		M_PrintWhite (16, 28,  "Programming        Art \n");
+		M_Print      (16, 36,  " John Carmack       Adrian Carmack\n");
+		M_Print      (16, 44,  " Michael Abrash     Kevin Cloud\n");
+		M_Print      (16, 52,  " John Cash          Paul Steed\n");
+		M_Print      (16, 60,  " Dave 'Zoid' Kirsch\n");
+		M_PrintWhite (16, 68,  "Design             Biz\n");
+		M_Print      (16, 76,  " John Romero        Jay Wilbur\n");
+		M_Print      (16, 84,  " Sandy Petersen     Mike Wilson\n");
+		M_Print      (16, 92,  " American McGee     Donna Jackson\n");
+		M_Print      (16, 100, " Tim Willits        Todd Hollenshead\n");
+		M_PrintWhite (16, 108, "Support            Projects\n");
+		M_Print      (16, 116, " Barrett Alexander  Shawn Green\n");
+		M_PrintWhite (16, 124, "Sound Effects\n");
+		M_Print      (16, 132, " Trent Reznor and Nine Inch Nails\n\n");
+		M_PrintWhite (16, 140, "Quake is a trademark of Id Software,\n");
+		M_PrintWhite (16, 148, "inc., (c)1996 Id Software, inc. All\n");
+		M_PrintWhite (16, 156, "rights reserved. NIN logo is a\n");
+		M_PrintWhite (16, 164, "registered trademark licensed to\n");
+		M_PrintWhite (16, 172, "Nothing Interactive, Inc. All rights\n");
+		M_PrintWhite (16, 180, "reserved. Press y to exit\n");
+	} else {
+		M_DrawTextBox(56, 76, 24, 4);
+		M_Print(64, 84,  quitMessage[msgNumber * 4 + 0]);
+		M_Print(64, 92,  quitMessage[msgNumber * 4 + 1]);
+		M_Print(64, 100, quitMessage[msgNumber * 4 + 2]);
+		M_Print(64, 108, quitMessage[msgNumber * 4 + 3]);
+	}
 }
 
 void M_Menu_LanConfig_f()
@@ -3720,6 +3746,8 @@ void M_ServerList_Key(s32 k)
 
 void M_Init()
 {
+	Cvar_RegisterVariable(&win_quit);
+
 	Cmd_AddCommand("togglemenu", M_ToggleMenu_f);
 	Cmd_AddCommand("menu_main", M_Menu_Main_f);
 	Cmd_AddCommand("menu_singleplayer", M_Menu_SinglePlayer_f);


### PR DESCRIPTION
I've debated on submitting this for a couple weeks, as it feels like a very cosmetic feature, but I H_A_T_E features that are exclusive to Windows, so this is my way of getting the best of both worlds!

It does suck that with this, the credits are hardcoded into the exit screen. But when used with the quick_exit cvar, it's just like WinQuake, but on any supported platform!

Definitely silly, but feel free to issue feedback or change it in some way if you think it's worth merging :P 

With love,
Luka~