### PR TITLE
r_showtris wireframe view beta - Now in Software!

### DIFF
--- a/src/d_polyse.c
+++ b/src/d_polyse.c
@@ -9,6 +9,7 @@ extern cvar_t r_showtris;
 typedef struct { int x0, y0, x1, y1; } debugline_t;
 extern debugline_t r_debuglines[];
 extern int r_numdebuglines;
+extern void R_DrawDebugLine(int x0, int y0, int x1, int y1, u8 color);
 #define MAX_DEBUG_LINES 16384
 
 static s32 r_p0[6], r_p1[6], r_p2[6];
@@ -150,24 +151,9 @@ void D_DrawSubdiv()
 		finalvert_t *i2 = pfv + ptri[i].vertindex[2];
 
 		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES - 3) {
-			// edge 0-1
-			r_debuglines[r_numdebuglines].x0 = i0->v[0];
-			r_debuglines[r_numdebuglines].y0 = i0->v[1];
-			r_debuglines[r_numdebuglines].x1 = i1->v[0];
-			r_debuglines[r_numdebuglines].y1 = i1->v[1];
-			r_numdebuglines++;
-			// edge 1-2
-			r_debuglines[r_numdebuglines].x0 = i1->v[0];
-			r_debuglines[r_numdebuglines].y0 = i1->v[1];
-			r_debuglines[r_numdebuglines].x1 = i2->v[0];
-			r_debuglines[r_numdebuglines].y1 = i2->v[1];
-			r_numdebuglines++;
-			// edge 2-0
-			r_debuglines[r_numdebuglines].x0 = i2->v[0];
-			r_debuglines[r_numdebuglines].y0 = i2->v[1];
-			r_debuglines[r_numdebuglines].x1 = i0->v[0];
-			r_debuglines[r_numdebuglines].y1 = i0->v[1];
-			r_numdebuglines++;
+            R_DrawDebugLine(i0->v[0], i0->v[1], i1->v[0], i1->v[1], 15);
+            R_DrawDebugLine(i1->v[0], i1->v[1], i2->v[0], i2->v[1], 15);
+            R_DrawDebugLine(i2->v[0], i2->v[1], i0->v[0], i0->v[1], 15);
 		}
 
 		if(((i0->v[1]-i1->v[1])*(i0->v[0]-i2->v[0])-(i0->v[0]-i1->v[0])
@@ -207,24 +193,9 @@ void D_DrawNonSubdiv()
 
 		// wireframe hook
 		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES - 3) {
-			// edge 0-1
-			r_debuglines[r_numdebuglines].x0 = i0->v[0];
-			r_debuglines[r_numdebuglines].y0 = i0->v[1];
-			r_debuglines[r_numdebuglines].x1 = i1->v[0];
-			r_debuglines[r_numdebuglines].y1 = i1->v[1];
-			r_numdebuglines++;
-			// edge 1-2
-			r_debuglines[r_numdebuglines].x0 = i1->v[0];
-			r_debuglines[r_numdebuglines].y0 = i1->v[1];
-			r_debuglines[r_numdebuglines].x1 = i2->v[0];
-			r_debuglines[r_numdebuglines].y1 = i2->v[1];
-			r_numdebuglines++;
-			// edge 2-0
-			r_debuglines[r_numdebuglines].x0 = i2->v[0];
-			r_debuglines[r_numdebuglines].y0 = i2->v[1];
-			r_debuglines[r_numdebuglines].x1 = i0->v[0];
-			r_debuglines[r_numdebuglines].y1 = i0->v[1];
-			r_numdebuglines++;
+			R_DrawDebugLine(i0->v[0], i0->v[1], i1->v[0], i1->v[1], 15);
+			R_DrawDebugLine(i1->v[0], i1->v[1], i2->v[0], i2->v[1], 15);
+			R_DrawDebugLine(i2->v[0], i2->v[1], i0->v[0], i0->v[1], 15);
 		}
 
 		d_xdenom=(i0->v[1]-i1->v[1])*(i0->v[0]-i2->v[0])-

--- a/src/d_polyse.c
+++ b/src/d_polyse.c
@@ -5,6 +5,12 @@
 
 #include "quakedef.h"
 
+extern cvar_t r_showtris;
+typedef struct { int x0, y0, x1, y1; } debugline_t;
+extern debugline_t r_debuglines[];
+extern int r_numdebuglines;
+#define MAX_DEBUG_LINES 16384
+
 static s32 r_p0[6], r_p1[6], r_p2[6];
 static u8 *d_pcolormap;
 static s32 d_xdenom;
@@ -142,6 +148,28 @@ void D_DrawSubdiv()
 		finalvert_t *i0 = pfv + ptri[i].vertindex[0];
 		finalvert_t *i1 = pfv + ptri[i].vertindex[1];
 		finalvert_t *i2 = pfv + ptri[i].vertindex[2];
+
+		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES - 3) {
+			// edge 0-1
+			r_debuglines[r_numdebuglines].x0 = i0->v[0];
+			r_debuglines[r_numdebuglines].y0 = i0->v[1];
+			r_debuglines[r_numdebuglines].x1 = i1->v[0];
+			r_debuglines[r_numdebuglines].y1 = i1->v[1];
+			r_numdebuglines++;
+			// edge 1-2
+			r_debuglines[r_numdebuglines].x0 = i1->v[0];
+			r_debuglines[r_numdebuglines].y0 = i1->v[1];
+			r_debuglines[r_numdebuglines].x1 = i2->v[0];
+			r_debuglines[r_numdebuglines].y1 = i2->v[1];
+			r_numdebuglines++;
+			// edge 2-0
+			r_debuglines[r_numdebuglines].x0 = i2->v[0];
+			r_debuglines[r_numdebuglines].y0 = i2->v[1];
+			r_debuglines[r_numdebuglines].x1 = i0->v[0];
+			r_debuglines[r_numdebuglines].y1 = i0->v[1];
+			r_numdebuglines++;
+		}
+
 		if(((i0->v[1]-i1->v[1])*(i0->v[0]-i2->v[0])-(i0->v[0]-i1->v[0])
 					*(i0->v[1]-i2->v[1]))>=0)
 			continue;
@@ -176,6 +204,29 @@ void D_DrawNonSubdiv()
 		finalvert_t *i0 = pfv + ptri->vertindex[0];
 		finalvert_t *i1 = pfv + ptri->vertindex[1];
 		finalvert_t *i2 = pfv + ptri->vertindex[2];
+
+		// wireframe hook
+		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES - 3) {
+			// edge 0-1
+			r_debuglines[r_numdebuglines].x0 = i0->v[0];
+			r_debuglines[r_numdebuglines].y0 = i0->v[1];
+			r_debuglines[r_numdebuglines].x1 = i1->v[0];
+			r_debuglines[r_numdebuglines].y1 = i1->v[1];
+			r_numdebuglines++;
+			// edge 1-2
+			r_debuglines[r_numdebuglines].x0 = i1->v[0];
+			r_debuglines[r_numdebuglines].y0 = i1->v[1];
+			r_debuglines[r_numdebuglines].x1 = i2->v[0];
+			r_debuglines[r_numdebuglines].y1 = i2->v[1];
+			r_numdebuglines++;
+			// edge 2-0
+			r_debuglines[r_numdebuglines].x0 = i2->v[0];
+			r_debuglines[r_numdebuglines].y0 = i2->v[1];
+			r_debuglines[r_numdebuglines].x1 = i0->v[0];
+			r_debuglines[r_numdebuglines].y1 = i0->v[1];
+			r_numdebuglines++;
+		}
+
 		d_xdenom=(i0->v[1]-i1->v[1])*(i0->v[0]-i2->v[0])-
 			(i0->v[0]-i1->v[0])*(i0->v[1]-i2->v[1]);
 		if (d_xdenom >= 0)

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -5,6 +5,8 @@ extern cvar_t r_showtris;
 typedef struct { int x0, y0, x1, y1; } debugline_t;
 extern debugline_t r_debuglines[];
 extern int r_numdebuglines;
+extern void R_DrawDebugLine3D(vec3_t p1, vec3_t p2);
+extern bool R_ProjectPointToScreen(vec3_t world, int *screenX, int *screenY);
 #define MAX_DEBUG_LINES 16384
 
 static u32 cacheoffset;
@@ -77,14 +79,6 @@ void R_EmitEdge(mvertex_t *pv0, mvertex_t *pv1)
 		lzi0 = r_lzi1;
 	if (lzi0 > r_nearzi) // for mipmap finding
 		r_nearzi = lzi0;
-
-		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES) {
-			r_debuglines[r_numdebuglines].x0 = (int)u0;
-			r_debuglines[r_numdebuglines].y0 = (int)v0;
-			r_debuglines[r_numdebuglines].x1 = (int)r_u1;
-			r_debuglines[r_numdebuglines].y1 = (int)r_v1;
-			r_numdebuglines++;
-		}
 
 	// for right edges, all we want is the effect on 1/z
 	if (r_nearzionly)
@@ -283,6 +277,39 @@ void R_RenderFace(msurface_t *fa, s32 clipflags)
 	medge_t *pedges, tedge;
 	pedges = currententity->model->edges;
 	r_lastvertvalid = 0;
+
+    // --- UNIFIED BSP GEOMETRY HOOK ---
+	if (r_showtris.value) {
+		mvertex_t *first_vert = NULL;
+		mvertex_t *prev_vert = NULL;
+
+		for (i = 0; i < fa->numedges; i++) {
+			s32 lindex = currententity->model->surfedges[fa->firstedge + i];
+			mvertex_t *vert;
+
+			if (lindex > 0) vert = &r_pcurrentvertbase[pedges[lindex].v[0]];
+			else vert = &r_pcurrentvertbase[pedges[-lindex].v[1]];
+
+			if (i == 0) {
+				first_vert = vert;
+			} else {
+				// 1. Draw perimeter edge
+				R_DrawDebugLine3D(prev_vert->position, vert->position);
+
+				// 2. Draw inner triangle diagonal if in mode 1
+				if (r_showtris.value == 1 && i > 1 && i < fa->numedges - 1) {
+					R_DrawDebugLine3D(first_vert->position, vert->position);
+				}
+			}
+			prev_vert = vert;
+		}
+		// 3. Close the perimeter loop
+		if (fa->numedges >= 3) {
+			R_DrawDebugLine3D(prev_vert->position, first_vert->position);
+		}
+	}
+	// ---------------------------------
+
 	for (i = 0; i < fa->numedges; i++) {
 		s32 lindex = currententity->model->surfedges[fa->firstedge + i];
 		if (lindex > 0) {
@@ -419,7 +446,7 @@ void R_RenderBmodelFace(bedge_t *pedges, msurface_t *psurf)
 	// this is a dummy to give the caching mechanism someplace to write to
 	r_pedge = &tedge;
 	clipplane_t *pclip = NULL; // set up clip planes
-	s32 i = 3; 
+	s32 i = 3;
 	u32 mask = 0x08;
 	for (; i >= 0; i--, mask >>= 1) {
 		if (r_clipflags & mask) {

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -1,6 +1,12 @@
 // Copyright (C) 1996-1997 Id Software, Inc. GPLv3 See LICENSE for details.
 #include "quakedef.h"
 
+extern cvar_t r_showtris;
+typedef struct { int x0, y0, x1, y1; } debugline_t;
+extern debugline_t r_debuglines[];
+extern int r_numdebuglines;
+#define MAX_DEBUG_LINES 16384
+
 static u32 cacheoffset;
 static medge_t tedge;
 static medge_t *r_pedge;
@@ -71,6 +77,15 @@ void R_EmitEdge(mvertex_t *pv0, mvertex_t *pv1)
 		lzi0 = r_lzi1;
 	if (lzi0 > r_nearzi) // for mipmap finding
 		r_nearzi = lzi0;
+
+		if (r_showtris.value && r_numdebuglines < MAX_DEBUG_LINES) {
+			r_debuglines[r_numdebuglines].x0 = (int)u0;
+			r_debuglines[r_numdebuglines].y0 = (int)v0;
+			r_debuglines[r_numdebuglines].x1 = (int)r_u1;
+			r_debuglines[r_numdebuglines].y1 = (int)r_v1;
+			r_numdebuglines++;
+		}
+
 	// for right edges, all we want is the effect on 1/z
 	if (r_nearzionly)
 		return;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -7,79 +7,221 @@ cvar_t r_showtris = {"r_showtris", "0"};
 typedef struct { int x0, y0, x1, y1; } debugline_t;
 debugline_t r_debuglines[MAX_DEBUG_LINES];
 int r_numdebuglines = 0;
+// point ent storage
+typedef struct {vec3_t origin;} debugpoint_t;
+#define MAX_DEBUG_POINTS 2048
+debugpoint_t r_debugpoints[MAX_DEBUG_POINTS];
+int r_numdebugpoints = 0;
 
-// Helper to project a 3D world coordinate into a 2D screen coordinate
-static bool R_ProjectPointToScreen(vec3_t world, int *screenX, int *screenY) {
+// Helper to project a 3D point (Used by point entities)
+bool R_ProjectPointToScreen(vec3_t world, int *screenX, int *screenY) {
     vec3_t local, transformed;
-
-    // Transform against the view
-    VectorSubtract(world, modelorg, local);
+    VectorSubtract(world, r_origin, local);
     TransformVector(local, transformed);
 
-    // Don't draw points behind the camera
+    // Revert the hack: strictly cull points behind the camera
     if (transformed[2] < NEAR_CLIP) return false;
 
     float lzi = 1.0 / transformed[2];
-
-    // Apply field of view scaling
-    float u = xcenter + (xscale * lzi) * transformed[0];
-    float v = ycenter - (yscale * lzi) * transformed[1];
-
-    *screenX = (int)u;
-    *screenY = (int)v;
+    *screenX = (int)(xcenter + (xscale * lzi) * transformed[0]);
+    *screenY = (int)(ycenter - (yscale * lzi) * transformed[1]);
     return true;
 }
 
-// Function to calculate all 8 corners and push the 12 edges to our buffer
+// NEW: True 3D Line Clipping and Projection
+void R_DrawDebugLine3D(vec3_t p1, vec3_t p2) {
+    vec3_t t1, t2, local1, local2;
+
+    // Transform both points to view space
+    VectorSubtract(p1, r_origin, local1);
+    TransformVector(local1, t1);
+    VectorSubtract(p2, r_origin, local2);
+    TransformVector(local2, t2);
+
+    // If both points are entirely behind the camera, discard the line
+    if (t1[2] < NEAR_CLIP && t2[2] < NEAR_CLIP) return;
+
+    // If the line crosses the near plane, interpolate the X/Y coordinates
+    // to exactly where it intersects the near plane to prevent warping.
+    if (t1[2] < NEAR_CLIP) {
+        float frac = (NEAR_CLIP - t1[2]) / (t2[2] - t1[2]);
+        t1[0] += frac * (t2[0] - t1[0]);
+        t1[1] += frac * (t2[1] - t1[1]);
+        t1[2] = NEAR_CLIP;
+    } else if (t2[2] < NEAR_CLIP) {
+        float frac = (NEAR_CLIP - t2[2]) / (t1[2] - t2[2]);
+        t2[0] += frac * (t1[0] - t2[0]);
+        t2[1] += frac * (t1[1] - t2[1]);
+        t2[2] = NEAR_CLIP;
+    }
+
+    // Project the safely clipped 3D segment to 2D
+    float lzi1 = 1.0 / t1[2];
+    float lzi2 = 1.0 / t2[2];
+
+    if (r_numdebuglines < MAX_DEBUG_LINES) {
+        r_debuglines[r_numdebuglines].x0 = (int)(xcenter + (xscale * lzi1) * t1[0]);
+        r_debuglines[r_numdebuglines].y0 = (int)(ycenter - (yscale * lzi1) * t1[1]);
+        r_debuglines[r_numdebuglines].x1 = (int)(xcenter + (xscale * lzi2) * t2[0]);
+        r_debuglines[r_numdebuglines].y1 = (int)(ycenter - (yscale * lzi2) * t2[1]);
+        r_numdebuglines++;
+    }
+}
+
+// Bounding box generation is now incredibly simple and immune to camera glitches
 void R_DebugDrawBBox(vec3_t origin, vec3_t mins, vec3_t maxs) {
     vec3_t corners[8];
-    int pt[8][2];
-    bool valid[8];
-
-    // Generate the 8 corners of the AABB
     for (int i = 0; i < 8; i++) {
         corners[i][0] = origin[0] + ((i & 1) ? maxs[0] : mins[0]);
         corners[i][1] = origin[1] + ((i & 2) ? maxs[1] : mins[1]);
         corners[i][2] = origin[2] + ((i & 4) ? maxs[2] : mins[2]);
-        valid[i] = R_ProjectPointToScreen(corners[i], &pt[i][0], &pt[i][1]);
     }
 
-    // Helper macro to push a line to the buffer if both points are valid
-    #define PUSH_BBOX_LINE(a, b) \
-        if (valid[a] && valid[b] && r_numdebuglines < MAX_DEBUG_LINES) { \
-            r_debuglines[r_numdebuglines].x0 = pt[a][0]; \
-            r_debuglines[r_numdebuglines].y0 = pt[a][1]; \
-            r_debuglines[r_numdebuglines].x1 = pt[b][0]; \
-            r_debuglines[r_numdebuglines].y1 = pt[b][1]; \
-            r_numdebuglines++; \
-        }
-
     // Bottom face
-    PUSH_BBOX_LINE(0, 1); PUSH_BBOX_LINE(1, 3);
-    PUSH_BBOX_LINE(3, 2); PUSH_BBOX_LINE(2, 0);
+    R_DrawDebugLine3D(corners[0], corners[1]); R_DrawDebugLine3D(corners[1], corners[3]);
+    R_DrawDebugLine3D(corners[3], corners[2]); R_DrawDebugLine3D(corners[2], corners[0]);
     // Top face
-    PUSH_BBOX_LINE(4, 5); PUSH_BBOX_LINE(5, 7);
-    PUSH_BBOX_LINE(7, 6); PUSH_BBOX_LINE(6, 4);
+    R_DrawDebugLine3D(corners[4], corners[5]); R_DrawDebugLine3D(corners[5], corners[7]);
+    R_DrawDebugLine3D(corners[7], corners[6]); R_DrawDebugLine3D(corners[6], corners[4]);
     // Vertical edges connecting top and bottom
-    PUSH_BBOX_LINE(0, 4); PUSH_BBOX_LINE(1, 5);
-    PUSH_BBOX_LINE(2, 6); PUSH_BBOX_LINE(3, 7);
+    R_DrawDebugLine3D(corners[0], corners[4]); R_DrawDebugLine3D(corners[1], corners[5]);
+    R_DrawDebugLine3D(corners[2], corners[6]); R_DrawDebugLine3D(corners[3], corners[7]);
 }
 
-// Basic Bresenham algorithm directly writing to 8-bit frame buffer
+// --- 2D Screen Clipping Definitions ---
+#define CLIP_LEFT   1
+#define CLIP_RIGHT  2
+#define CLIP_BOTTOM 4
+#define CLIP_TOP    8
+
+static int ComputeOutCode(int x, int y, int w, int h) {
+    int code = 0;
+    if (x < 0) code |= CLIP_LEFT;
+    else if (x >= w) code |= CLIP_RIGHT;
+    if (y < 0) code |= CLIP_TOP;
+    else if (y >= h) code |= CLIP_BOTTOM;
+    return code;
+}
+
+// Highly optimized Bresenham algorithm with Cohen-Sutherland pre-clipping
 void R_DrawDebugLine(int x0, int y0, int x1, int y1, u8 color) {
+    int w = vid.width;
+    int h = vid.height;
+
+    // 1. Cohen-Sutherland 2D Clipping
+    int outcode0 = ComputeOutCode(x0, y0, w, h);
+    int outcode1 = ComputeOutCode(x1, y1, w, h);
+    bool accept = false;
+
+    while (1) {
+        if (!(outcode0 | outcode1)) { // Bitwise OR is 0: Line is completely inside bounds
+            accept = true;
+            break;
+        } else if (outcode0 & outcode1) { // Bitwise AND is not 0: Line is completely outside bounds
+            break;
+        } else {
+            // Line is partially inside. Calculate the intersection point.
+            int x, y;
+            int outcodeOut = outcode0 ? outcode0 : outcode1;
+
+            if (outcodeOut & CLIP_BOTTOM) {
+                x = x0 + (x1 - x0) * (h - 1 - y0) / (y1 - y0);
+                y = h - 1;
+            } else if (outcodeOut & CLIP_TOP) {
+                x = x0 + (x1 - x0) * (0 - y0) / (y1 - y0);
+                y = 0;
+            } else if (outcodeOut & CLIP_RIGHT) {
+                y = y0 + (y1 - y0) * (w - 1 - x0) / (x1 - x0);
+                x = w - 1;
+            } else if (outcodeOut & CLIP_LEFT) {
+                y = y0 + (y1 - y0) * (0 - x0) / (x1 - x0);
+                x = 0;
+            }
+
+            // Move the outside point to the intersection point
+            if (outcodeOut == outcode0) {
+                x0 = x; y0 = y;
+                outcode0 = ComputeOutCode(x0, y0, w, h);
+            } else {
+                x1 = x; y1 = y;
+                outcode1 = ComputeOutCode(x1, y1, w, h);
+            }
+        }
+    }
+
+    // If the line was completely off-screen, abort drawing
+    if (!accept) return;
+
+    // 2. Fast Bresenham Rasterization
     int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
     int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
     int err = dx + dy, e2;
 
     for (;;) {
-        // Bounds checking against the screen frame
-        if (x0 >= 0 && x0 < vid.width && y0 >= 0 && y0 < vid.height) {
-            vid.buffer[y0 * vid.width + x0] = color;
+        // We keep a minor bounds check here strictly as a failsafe against
+        // integer division rounding errors from the clipping math above.
+        if (x0 >= 0 && x0 < w && y0 >= 0 && y0 < h) {
+            vid.buffer[y0 * w + x0] = color;
         }
         if (x0 == x1 && y0 == y1) break;
         e2 = 2 * err;
         if (e2 >= dy) { err += dy; x0 += sx; }
         if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+}
+
+void R_ParseDebugEntities() {
+    r_numdebugpoints = 0;
+    if (!cl.worldmodel || !cl.worldmodel->entities) return;
+
+    const char *data = cl.worldmodel->entities;
+    char key[128], value[4096];
+
+    while (1) {
+        data = COM_Parse(data);
+        if (!data) break;
+        if (com_token[0] != '{') continue;
+
+        bool is_point = true;
+        vec3_t parsed_origin = {0, 0, 0};
+
+        while (1) {
+            data = COM_Parse(data);
+            if (!data || com_token[0] == '}') break;
+
+            strcpy(key, com_token);
+            data = COM_ParseEx(data, CPE_ALLOWTRUNC);
+            if (!data) break;
+            strcpy(value, com_token);
+
+            if (!strcmp(key, "origin")) {
+                sscanf(value, "%f %f %f", &parsed_origin[0], &parsed_origin[1], &parsed_origin[2]);
+            } else if (!strcmp(key, "model")) {
+                is_point = false; // Has a brush model, not a point entity
+            }
+        }
+
+        if (is_point && (parsed_origin[0] != 0 || parsed_origin[1] != 0 || parsed_origin[2] != 0)) {
+            if (r_numdebugpoints < MAX_DEBUG_POINTS) {
+                VectorCopy(parsed_origin, r_debugpoints[r_numdebugpoints].origin);
+                r_numdebugpoints++;
+            }
+        }
+    }
+}
+
+void R_DebugDrawPoint(vec3_t origin) {
+    int sx, sy;
+    if (R_ProjectPointToScreen(origin, &sx, &sy)) {
+        if (r_numdebuglines < MAX_DEBUG_LINES - 2) {
+            int size = 4;
+            r_debuglines[r_numdebuglines].x0 = sx - size; r_debuglines[r_numdebuglines].y0 = sy;
+            r_debuglines[r_numdebuglines].x1 = sx + size; r_debuglines[r_numdebuglines].y1 = sy;
+            r_numdebuglines++;
+            r_debuglines[r_numdebuglines].x0 = sx; r_debuglines[r_numdebuglines].y0 = sy - size;
+            r_debuglines[r_numdebuglines].x1 = sx; r_debuglines[r_numdebuglines].y1 = sy + size;
+            r_numdebuglines++;
+        }
     }
 }
 
@@ -273,6 +415,7 @@ void R_NewMap()
 	Sky_NewMap();
 	Fog_ParseWorldspawn();
 	R_ParseWorldspawn();
+	R_ParseDebugEntities(); //init point-ent wireframe
 }
 
 void R_SetVrect(vrect_t *pvrectin, vrect_t *pvrect, s32 lineadj)
@@ -417,6 +560,10 @@ void R_DrawEntitiesOnList()
 		if(currententity == &cl_entities[cl.viewentity]
 			&& !chase_active.value)
 			continue; // don't draw the player
+
+        if (r_showtris.value && currententity->model)
+                R_DebugDrawBBox(currententity->origin, currententity->model->mins, currententity->model->maxs);
+
 		switch(currententity->model->type){
 		case mod_sprite:
 			VectorCopy(currententity->origin, r_entorigin);
@@ -426,11 +573,6 @@ void R_DrawEntitiesOnList()
 		case mod_alias:
 			VectorCopy(currententity->origin, r_entorigin);
 			VectorSubtract(r_origin, r_entorigin, modelorg);
-			if (r_showtris.value) {
-				R_DebugDrawBBox(currententity->origin,
-								currententity->model->mins,
-								currententity->model->maxs);
-			}
 			// see if the bounding box lets us trivially reject, also sets
 			// trivial accept status
 			if(R_AliasCheckBBox()){
@@ -713,10 +855,12 @@ void R_RenderView()
 	V_SetContentsColor(r_viewleaf->contents);
 	// process and flush buffer
 	if (r_showtris.value) {
+        for (int i = 0; i < r_numdebugpoints; i++)
+            R_DebugDrawPoint(r_debugpoints[i].origin);
 		for (int i = 0; i < r_numdebuglines; i++) {
 			R_DrawDebugLine(r_debuglines[i].x0, r_debuglines[i].y0,
 							r_debuglines[i].x1, r_debuglines[i].y1, 15);
 		}
+        r_numdebuglines = 0; // reset for next frame
 	}
-	r_numdebuglines = 0; // reset for next frame
 }

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -1,6 +1,88 @@
 // Copyright (C) 1996-1997 Id Software, Inc. GPLv3 See LICENSE for details.
 #include "quakedef.h"
 
+cvar_t r_showtris = {"r_showtris", "0"};
+// Deferred line buffer for wireframe overlay
+#define MAX_DEBUG_LINES 16384
+typedef struct { int x0, y0, x1, y1; } debugline_t;
+debugline_t r_debuglines[MAX_DEBUG_LINES];
+int r_numdebuglines = 0;
+
+// Helper to project a 3D world coordinate into a 2D screen coordinate
+static bool R_ProjectPointToScreen(vec3_t world, int *screenX, int *screenY) {
+    vec3_t local, transformed;
+
+    // Transform against the view
+    VectorSubtract(world, modelorg, local);
+    TransformVector(local, transformed);
+
+    // Don't draw points behind the camera
+    if (transformed[2] < NEAR_CLIP) return false;
+
+    float lzi = 1.0 / transformed[2];
+
+    // Apply field of view scaling
+    float u = xcenter + (xscale * lzi) * transformed[0];
+    float v = ycenter - (yscale * lzi) * transformed[1];
+
+    *screenX = (int)u;
+    *screenY = (int)v;
+    return true;
+}
+
+// Function to calculate all 8 corners and push the 12 edges to our buffer
+void R_DebugDrawBBox(vec3_t origin, vec3_t mins, vec3_t maxs) {
+    vec3_t corners[8];
+    int pt[8][2];
+    bool valid[8];
+
+    // Generate the 8 corners of the AABB
+    for (int i = 0; i < 8; i++) {
+        corners[i][0] = origin[0] + ((i & 1) ? maxs[0] : mins[0]);
+        corners[i][1] = origin[1] + ((i & 2) ? maxs[1] : mins[1]);
+        corners[i][2] = origin[2] + ((i & 4) ? maxs[2] : mins[2]);
+        valid[i] = R_ProjectPointToScreen(corners[i], &pt[i][0], &pt[i][1]);
+    }
+
+    // Helper macro to push a line to the buffer if both points are valid
+    #define PUSH_BBOX_LINE(a, b) \
+        if (valid[a] && valid[b] && r_numdebuglines < MAX_DEBUG_LINES) { \
+            r_debuglines[r_numdebuglines].x0 = pt[a][0]; \
+            r_debuglines[r_numdebuglines].y0 = pt[a][1]; \
+            r_debuglines[r_numdebuglines].x1 = pt[b][0]; \
+            r_debuglines[r_numdebuglines].y1 = pt[b][1]; \
+            r_numdebuglines++; \
+        }
+
+    // Bottom face
+    PUSH_BBOX_LINE(0, 1); PUSH_BBOX_LINE(1, 3);
+    PUSH_BBOX_LINE(3, 2); PUSH_BBOX_LINE(2, 0);
+    // Top face
+    PUSH_BBOX_LINE(4, 5); PUSH_BBOX_LINE(5, 7);
+    PUSH_BBOX_LINE(7, 6); PUSH_BBOX_LINE(6, 4);
+    // Vertical edges connecting top and bottom
+    PUSH_BBOX_LINE(0, 4); PUSH_BBOX_LINE(1, 5);
+    PUSH_BBOX_LINE(2, 6); PUSH_BBOX_LINE(3, 7);
+}
+
+// Basic Bresenham algorithm directly writing to 8-bit frame buffer
+void R_DrawDebugLine(int x0, int y0, int x1, int y1, u8 color) {
+    int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+    int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+    int err = dx + dy, e2;
+
+    for (;;) {
+        // Bounds checking against the screen frame
+        if (x0 >= 0 && x0 < vid.width && y0 >= 0 && y0 < vid.height) {
+            vid.buffer[y0 * vid.width + x0] = color;
+        }
+        if (x0 == x1 && y0 == y1) break;
+        e2 = 2 * err;
+        if (e2 >= dy) { err += dy; x0 += sx; }
+        if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+}
+
 static vec3_t viewlightvec;
 static alight_t r_viewlighting = { 128, 192, viewlightvec };
 static f32 verticalFieldOfView;
@@ -118,6 +200,7 @@ void R_Init()
 	Cvar_RegisterVariable(&lyr_crosshair);
 	Cvar_RegisterVariable(&r_renderscale);
 	Cvar_RegisterVariable(&cl_gun_fovscale);
+	Cvar_RegisterVariable(&r_showtris);
 	Cvar_SetCallback(&r_labmixpal, R_BuildColorMixLUT);
 	Cvar_SetCallback(&r_rgblighting, D_FlushCaches);
 	Cvar_SetCallback(&r_fogbrightness, Fog_SetPalIndex);
@@ -174,7 +257,7 @@ void Pal_ParseWorldspawn ()
 void R_NewMap()
 {
 	Pal_ParseWorldspawn();
-	R_InitSkyBox(); // Manoel Kasimier - skyboxes 
+	R_InitSkyBox(); // Manoel Kasimier - skyboxes
 	// clear out efrags in case the level hasn't been reloaded
 	for(s32 i = 0; i < cl.worldmodel->numleafs; i++)
 		cl.worldmodel->leafs[i].efrags = NULL;
@@ -257,7 +340,7 @@ void R_ViewChanged(vrect_t *pvrect, s32 lineadj, f32 aspect)
 	// values for perspective projection
 	// if math were exact, the values would range from 0.5 to to range+0.5
 	// hopefully they wll be in the 0.000001 to range+.999999 and truncate
-	// the polygon rasterization will never render in the first row or 
+	// the polygon rasterization will never render in the first row or
 	// column but will definately render in the [range] row and column, so
 	// adjust the buffer origin to get an exact edge to edge fill
 	xcenter = ((f32)r_refdef.vrect.width*0.5)+r_refdef.vrect.x-0.5;
@@ -343,6 +426,11 @@ void R_DrawEntitiesOnList()
 		case mod_alias:
 			VectorCopy(currententity->origin, r_entorigin);
 			VectorSubtract(r_origin, r_entorigin, modelorg);
+			if (r_showtris.value) {
+				R_DebugDrawBBox(currententity->origin,
+								currententity->model->mins,
+								currententity->model->maxs);
+			}
 			// see if the bounding box lets us trivially reject, also sets
 			// trivial accept status
 			if(R_AliasCheckBBox()){
@@ -553,7 +641,7 @@ void R_DrawBEntitiesOnList()
 					}
 					currententity->topnode = NULL;
 				}
-				// put back world rotation and frustum clipping         
+				// put back world rotation and frustum clipping
 				// FIXME: R_RotateBmodel should just work off base_vxx
 				VectorCopy(base_vpn, vpn);
 				VectorCopy(base_vup, vup);
@@ -623,4 +711,12 @@ void R_RenderView()
 	if(fog_density < 1) R_DrawFog();
 	if(r_dspeeds.value) d_times[14] = Sys_DoubleTime();
 	V_SetContentsColor(r_viewleaf->contents);
+	// process and flush buffer
+	if (r_showtris.value) {
+		for (int i = 0; i < r_numdebuglines; i++) {
+			R_DrawDebugLine(r_debuglines[i].x0, r_debuglines[i].y0,
+							r_debuglines[i].x1, r_debuglines[i].y1, 15);
+		}
+	}
+	r_numdebuglines = 0; // reset for next frame
 }


### PR DESCRIPTION
Why do GL Renderer ports of everything get to have all the useful builtins i STG

anyway, source-port politics aside, here's a fully working rasterization injector thingy of sorts that allows you to view all polygonal faces rendered in a scene, on all geometry alias and BSP! (i guess also entity bounding boxes by default) <3

Disabling each identical wireframe hook in different functions can take away certain wireframe renders you may not want to see, but comes stock standard as Quakespasm's r_showtris display does, for alias, bsp, bboxes, etc.

There's no way to adjust the line width in-engine outside of video output resolution, where your desired resolution makes the lines (basically all models and edges) thicker or thinner.

If you wish to change the wireframe line color in your merge of this pull, in r_main, inside R_RenderView(), there's a for loop at the bottom of the function. At line 718, the `R_DebugDrawLine` call has a 15 at the end, this is the palette index the line renderer will use when running!

To elaborate, as I've edited this message a bit, the r_showtris cvar currently allows a wireframe overlay view on top of the rendered viewport to see the individual geometry of the level, all the models, and (after a few bug fixes get pushed soon) the bounding boxes of all entities as well (they currently render but at an unknown offset to the actual entity in-game). I plan on generating a 'triangle fan' for each BSP face so those get drawn instead of the raw faces; hopefully they'll match up to what QS would generate in its r_showtris view.

UPDATE: The update+fixes push is relatively stable, and handles a lot more geometry.
Use r_showtris 1 for that classic quakespasm feel. (Triangulated)
Because vanilla quake handles faces instead of triangles, r_showtris 2 shows you the proper rendering spans. (Cubic?)
both show point entities (currently NO distance clipping)

No BSP entity bboxes yet, this is done in QuakeC, and will require a secondary estimation wireframe based on the assumed entity size (haven't thought up a way to automate the check to see if the vecs match the QC entity code, if there is one)

This also means the bboxes for things like triggers are probably not going to be visible at this time, looking for a workaround to this... I'm sure that brush logic is handled somewhere else

It's currently USABLE, but a bit buggy around the edges. No crashes though! That's my metric for quitting for the night lmao

Feel free to edit away, or ask questions, I'll do my best to share what I THINK i know <3
Bless you and all your hard work <3