### PR TITLE
Menu: Previous Weapon Added

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1238,7 +1238,8 @@ void M_Options_Key(s32 k)
 
 s8 *bindnames[][2] = {
 	{ "+attack", "attack" },
-	{ "impulse 10", "change weapon" },
+	{ "impulse 10", "next weapon" },
+	{ "impulse 12", "previous weapon" },
 	{ "+jump", "jump / swim up" },
 	{ "+forward", "walk forward" },
 	{ "+back", "backpedal" },


### PR DESCRIPTION
I've added the "canonical" Impulse 12 command for choosing your previous weapon into the menu. 

OG Quake, I believe starting around v1.06 supports this, as well as the official remaster and many other sourceports. 
EDIT: OG Quake does not have a menu option for this input. But Impulse 12 is part of the 1.06 progs.

I've also changed "Change Weapon" to "Next Weapon".

I've compiled and verified it works.

<img width="892" height="646" alt="image" src="https://github.com/user-attachments/assets/9fd52d51-c0fa-464b-a5f6-9ec13285e9d6" />
