### PR TITLE
Mjolnir bind impulse fix

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -394,10 +394,21 @@ void Key_Bind_f()
 
 void Key_WriteBindings(FILE *f) // Writes lines containing "bind key value"
 {
+	//DM23 hipnotic support for mjolnir hammer impulse on 0 key
 	for(s32 i = 0; i < 256; i++)
-		if(keybindings[i] && *keybindings[i])
-			fprintf(f, "bind \"%s\" \"%s\"\n",
-				Key_KeynumToString(i), keybindings[i]);
+		if(i == 48)
+		{
+			if(hipnotic)
+				fprintf(f, "bind \"0\" \"impulse 226\"\n");
+			else
+				fprintf(f, "bind \"%s\" \"%s\"\n",
+						Key_KeynumToString(i), keybindings[i]);
+		}
+		else
+			if(keybindings[i] && *keybindings[i])
+				fprintf(f, "bind \"%s\" \"%s\"\n",
+					Key_KeynumToString(i), keybindings[i]);
+
 }
 
 void Key_SetDefaults() // CyanBun96: some paks don't include a default.cfg,
@@ -429,7 +440,10 @@ void Key_SetDefaults() // CyanBun96: some paks don't include a default.cfg,
 	Key_SetBinding('6', "impulse 6");
 	Key_SetBinding('7', "impulse 7");
 	Key_SetBinding('8', "impulse 8");
-	Key_SetBinding('0', "impulse 0");
+	if(hipnotic)//DM23 hipnotic support for mjolnir hammer impulse on 0 key
+		Key_SetBinding('0', "impulse 226");
+	else
+		Key_SetBinding('0', "impulse 0");
 	Key_SetBinding('/', "impulse 10");
 	Key_SetBinding(K_F1, "help");
 	Key_SetBinding(K_F2, "menu_save");

--- a/src/keys.c
+++ b/src/keys.c
@@ -394,7 +394,7 @@ void Key_Bind_f()
 
 void Key_WriteBindings(FILE *f) // Writes lines containing "bind key value"
 {
-	//DM23 hipnotic support for mjolnir hammer impulse on 0 key
+	//DM23: hipnotic support for mjolnir hammer impulse on 0 key
 	for(s32 i = 0; i < 256; i++)
 		if(i == 48)
 		{
@@ -440,7 +440,7 @@ void Key_SetDefaults() // CyanBun96: some paks don't include a default.cfg,
 	Key_SetBinding('6', "impulse 6");
 	Key_SetBinding('7', "impulse 7");
 	Key_SetBinding('8', "impulse 8");
-	if(hipnotic)//DM23 hipnotic support for mjolnir hammer impulse on 0 key
+	if(hipnotic) //DM23: hipnotic support for mjolnir hammer impulse on 0 key
 		Key_SetBinding('0', "impulse 226");
 	else
 		Key_SetBinding('0', "impulse 0");


### PR DESCRIPTION
**EDIT:** Editing Key_SetDefaults() is probably unnecessary because hipnotic includes a default.cfg. I was so focused on getting this working that I didn't stop to consider how silly it was.

I wanted to tackle the request to let you select Mjolnir with 0 on the number row. #138

I've modified two functions inside _keys.c_ to check if you're on hipnotic and apply the correct "impulse 226" binding.

1. Key_SetDefaults() checks if hipnotic and sets binding accordingly.
2. Key_WriteBindings() checks if keycode 48 and sets binding accordingly.

When default settings is loaded from the menu / console, it sets the binding. Config.cfg is save/loaded properly as well.

Everything seems to work besides one issue I'll discuss below.

**Issue regarding loading default settings**
Ordinarily I wouldn't make a pull request until I was 100% done, but I'm having some trouble with this last issue after a few hours. I figure it would be more useful to your project if I at least gave my incomplete work and report my issue / findings.

As stated, saving/loading config.cfg works fine, and loading default.cfg from the menu or console works fine. 

However, starting a game without a config.cfg and relying on the default.cfg seems to only load the id1/pak.0 default.cfg. I've even tested this with the _-game "hipnotic"_ launch command.

I've tested with a modified default.cfg in my _id1/pak0.pak_, and it does seem that the game just keeps loading the id1 default.cfg and not the hipnotic.cfg.

This is also true if I launch hipnotic and then run _exec quake.rc_. 

I'm more a hobbyist and game modder so I'm not sure how to best resolve this issue. Regardless, I hope this pull request may be somewhat useful to your project.
