### PR TITLE
made automatic main menu a toggle cvar

### DIFF
--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -465,6 +465,7 @@ void CL_Init()
 	Cvar_RegisterVariable(&cl_maxpitch); //johnfitz -- variable pitch clamp
 	Cvar_RegisterVariable(&cl_minpitch); //johnfitz -- variable pitch clamp
 	Cvar_RegisterVariable(&cl_startdemos);
+	Cvar_RegisterVariable(&cl_automenu);
 	Cmd_AddCommand("entities", CL_PrintEntities_f);
 	Cmd_AddCommand("disconnect", CL_Disconnect_f);
 	Cmd_AddCommand("record", CL_Record_f);

--- a/src/cvarlist.c
+++ b/src/cvarlist.c
@@ -244,6 +244,7 @@ cvar_t gl_cshiftpercent_bonus=           {"gl_cshiftpercent_bonus", "100",1,ZR};
 cvar_t gl_cshiftpercent_powerup=       {"gl_cshiftpercent_powerup", "100",1,ZR};
 cvar_t cl_gun_fovscale=                            {"cl_gun_fovscale","1",1,ZR};
 cvar_t cl_startdemos=                                {"cl_startdemos","1",1,ZR};
+cvar_t cl_automenu=									   {"cl_automenu","1",1,ZR};
 cvar_t ui_mouse=                                          {"ui_mouse","0",1,ZR};
 cvar_t ui_mouse_sound=                              {"ui_mouse_sound","0",1,ZR};
 cvar_t scr_saturntext=                              {"scr_saturntext","0",1,ZR};

--- a/src/cvarlist.h
+++ b/src/cvarlist.h
@@ -44,4 +44,4 @@ sv_autosave, sv_autosave_interval, sv_autoload, exitstyle, v_oldviewmodelpos,
 scr_centermenus, v_gunkick, gl_cshiftpercent_contents, gl_cshiftpercent_damage,
 gl_cshiftpercent_bonus, gl_cshiftpercent_powerup, aspectr_lock, cl_gun_fovscale,
 r_showtris_color, scr_saturntext, con_notifycenter, r_coarseocclusion,
-cl_startdemos;
+cl_startdemos, cl_automenu;

--- a/src/host_cmd.c
+++ b/src/host_cmd.c
@@ -1020,7 +1020,8 @@ void Host_Startdemos_f()
 		strncpy(cls.demos[i - 1], Cmd_Argv(i), sizeof(cls.demos[0])-1);
 	if(!sv.active && cls.demonum != -1 && !cls.demoplayback){
 		cls.demonum = 0;
-		Cbuf_InsertText ("menu_main\n");
+		if(cl_automenu.value)
+			Cbuf_InsertText("menu_main\n");
 		if (!cl_startdemos.value) {
 			cls.demonum = -1;
 			return;


### PR DESCRIPTION
So I love what you've been doing with the engine lately! It's becoming more and more its own beast and I'm excited as all get out about it <3 <3

So the automatic main menu on startup was kinda giving me FTE vibes, not that I hate FTEQuake at all, but for the vanilla look and feel, you can now set `cl_automenu` to 0!

Feel free to rename it if it might be confusing, I just wanted the pipeline set up :P

Blessings and cheers to u! <3

Regards,
-A chronically online dog